### PR TITLE
feat: set a max length for quotes when getting random

### DIFF
--- a/aurelius_tabs/meditations.js
+++ b/aurelius_tabs/meditations.js
@@ -1,8 +1,13 @@
 var INDEX = 0;
 var KEYS = Object.keys(MEDITATIONS);
+var MAX_LENGTH = 300;
 
 function getRandomIndex() {
   INDEX = Math.floor(Math.random() * Math.floor(KEYS.length));
+  // TODO: Feels wrong to have this here. Should be in a nicer place.
+  if (MAX_LENGTH > 0 && MEDITATIONS[KEYS[INDEX]].length > MAX_LENGTH) {
+    return getRandomIndex();
+  }
   return INDEX;
 }
 


### PR DESCRIPTION
Currently, the max length is hardcoded as 300. Don't really like that.
Need to see how to make it configurable from chrome rather than from the
code. Also don't particularly enjoy the implementation. There needs to
be a cleaner way to do that. Let's see.